### PR TITLE
GitHub actions for automatic builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Build release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-linux:
+    name: Build linux
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@master
+      - name: Build
+        run: docker run -it --rm -v `pwd`:/io -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest cd io && make build_linux
+
+
+  # build-windows:
+  #
+  # build-macos:
+  #
+  # release-to-pypi:
+  #   name: Release to Pypi
+  #   runs-on: ubuntu-18.04
+  #   steps:
+  #     - name: Checkout branch
+  #       uses: actions/checkout@master
+  #     - name: Setup python
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: '3.7'
+  #         architecture: x64
+  #     - name: Install dependencies
+  #       run: pip install -r dev-requirements.txt
+  #     - name: Build
+  #       run: python setup.py sdist bdist_wheel
+  #     - name: Upload
+  #       run: twine upload dist/*
+  #       env:
+  #         TWINE_REPOSITORY_URL: ${{ secrets.PYPI_URL }}
+  #         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+  #         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@master
       - name: Build
-        run: docker run --rm -v `pwd`:/io -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest cd io && make build_linux
+        run: docker run --rm -v `pwd`:/io -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux"
 
 
   # build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
           docker run --rm -v `pwd`:/io \
           -e RELEASE_OS=$RELEASE_OS \
           -e RELEASE_VERSION=$RELEASE_VERSION \
-          -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' \
           phusion/holy-build-box-64:latest /hbb_exe/activate-exec \
           bash -x -c "cd io && make build_$RELEASE_OS && make compile_release_$RELEASE_OS"
         env:
@@ -46,13 +45,7 @@ jobs:
         id: setup
         run: echo ::set-output name=RELEASE_VERSION::${GITHUB_REF##*/}
       - name: Build
-        run: |
-          docker run --rm -v `pwd`:/io \
-          -e RELEASE_OS=$RELEASE_OS \
-          -e RELEASE_VERSION=$RELEASE_VERSION \
-          -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' \
-          phusion/holy-build-box-64:latest /hbb_exe/activate-exec \
-          bash -x -c "cd io && make build_$RELEASE_OS && make compile_release_$RELEASE_OS"
+        run: make build_$RELEASE_OS && make compile_release_$RELEASE_OS
         env:
           RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
       - name: Upload to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,9 @@ jobs:
         run: echo ::set-output name=RELEASE_VERSION::${GITHUB_REF##*/}
       - name: Build
         run: |
-          docker run --rm -v `pwd`:/io \
-          -e RELEASE_OS=$RELEASE_OS \
-          -e RELEASE_VERSION=$RELEASE_VERSION \
-          phusion/holy-build-box-64:latest /hbb_exe/activate-exec \
-          bash -x -c "cd io && make build_$RELEASE_OS && make compile_release_$RELEASE_OS"
+          docker run --rm dockbuild/centos5:latest > ./dockbuild \
+          && chmod +x ./dockbuild \
+          && ./dockbuild bash -c "make build && make compile_release_$RELEASE_OS"
         env:
           RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
       - name: Upload to release
@@ -45,7 +43,7 @@ jobs:
         id: setup
         run: echo ::set-output name=RELEASE_VERSION::${GITHUB_REF##*/}
       - name: Build
-        run: make build_$RELEASE_OS && make compile_release_$RELEASE_OS
+        run: make build && make compile_release_$RELEASE_OS
         env:
           RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
       - name: Upload to release
@@ -56,28 +54,28 @@ jobs:
           asset_name: bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
           tag: ${{ github.ref }}
 
-  # build-windows:
-  #
-  # build-macos:
-  #
-  # release-to-pypi:
-  #   name: Release to Pypi
-  #   runs-on: ubuntu-18.04
-  #   steps:
-  #     - name: Checkout branch
-  #       uses: actions/checkout@master
-  #     - name: Setup python
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: '3.7'
-  #         architecture: x64
-  #     - name: Install dependencies
-  #       run: pip install -r dev-requirements.txt
-  #     - name: Build
-  #       run: python setup.py sdist bdist_wheel
-  #     - name: Upload
-  #       run: twine upload dist/*
-  #       env:
-  #         TWINE_REPOSITORY_URL: ${{ secrets.PYPI_URL }}
-  #         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-  #         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  build-windows:
+    name: Build windows
+    runs-on: ubuntu-18.04
+    env:
+      RELEASE_OS: windows
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@master
+      - name: Setup environment
+        id: setup
+        run: echo ::set-output name=RELEASE_VERSION::${GITHUB_REF##*/}
+      - name: Build
+        run: |
+          docker run --rm dockcross/windows-static-x64:20191127-92bdbca > ./dockcross \
+          && chmod +x ./dockcross \
+          && ./dockcross bash -c "make build && make compile_release_$RELEASE_OS"
+        env:
+          RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: release/bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          asset_name: bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,18 +8,25 @@ jobs:
   build-linux:
     name: Build linux
     runs-on: ubuntu-18.04
+    env:
+      RELEASE_OS: linux
     steps:
       - name: Checkout branch
         uses: actions/checkout@master
+      - name: Setup environment
+        id: setup
+        run: echo ::set-output name=RELEASE_VERSION::${GITHUB_REF##*/}
       - name: Build
-        run: docker run --rm -v `pwd`:/io -e RELEASE_OS='linux' -e RELEASE_VERSION=${GITHUB_REF##*/} -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
+        run: docker run --rm -v `pwd`:/io -e RELEASE_OS=$RELEASE_OS -e RELEASE_VERSION=$RELEASE_VERSION -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
+        env:
+          RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
       - name: Upload to release
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release/bustools_linux-${GITHUB_REF##*/}.tar.gz
-          asset_name: bustools_linux-${GITHUB_REF##*/}.tar.gz
-          tag: ${GITHUB_REF##*/}
+          file: release/bustools_linux-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          asset_name: bustools_linux-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          tag: ${{ github.ref }}
 
 
   # build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,6 @@ jobs:
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release/bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
-          asset_name: bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          file: release/bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.zip
+          asset_name: bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.zip
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,13 @@ jobs:
         id: setup
         run: echo ::set-output name=RELEASE_VERSION::${GITHUB_REF##*/}
       - name: Build
-        run: docker run --rm -v `pwd`:/io -e RELEASE_OS=$RELEASE_OS -e RELEASE_VERSION=$RELEASE_VERSION -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
+        run: |
+          docker run --rm -v `pwd`:/io \
+          -e RELEASE_OS=$RELEASE_OS \
+          -e RELEASE_VERSION=$RELEASE_VERSION \
+          -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' \
+          phusion/holy-build-box-64:latest /hbb_exe/activate-exec \
+          bash -x -c "cd io && make build_$RELEASE_OS && make compile_release_$RELEASE_OS"
         env:
           RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
       - name: Upload to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@master
       - name: Build
-        run: docker run -it --rm -v `pwd`:/io -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest cd io && make build_linux
+        run: docker run --rm -v `pwd`:/io -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest cd io && make build_linux
 
 
   # build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,20 @@ jobs:
   build-linux:
     name: Build linux
     runs-on: ubuntu-18.04
+    env:
+      RELEASE_OS: linux
     steps:
       - name: Checkout branch
         uses: actions/checkout@master
       - name: Build
-        run: docker run --rm -v `pwd`:/io -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux"
+        run: docker run --rm -v `pwd`:/io -e RELEASE_VERSION='$GITHUB_REF' -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: release/bustools_${RELEASE_OS}-${GITHUB_REF}.tar.gz
+          asset_name: bustools_${RELEASE_OS}-${GITHUB_REF}.tar.gz
+          tag: $GITHUB_REF
 
 
   # build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,18 @@ jobs:
   build-linux:
     name: Build linux
     runs-on: ubuntu-18.04
-    env:
-      RELEASE_OS: linux
     steps:
       - name: Checkout branch
         uses: actions/checkout@master
       - name: Build
-        run: docker run --rm -v `pwd`:/io -e RELEASE_VERSION='$GITHUB_REF' -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
+        run: docker run --rm -v `pwd`:/io -e RELEASE_OS='linux' -e RELEASE_VERSION=$GITHUB_REF -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
       - name: Upload to release
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release/bustools_${RELEASE_OS}-${GITHUB_REF}.tar.gz
-          asset_name: bustools_${RELEASE_OS}-${GITHUB_REF}.tar.gz
-          tag: $GITHUB_REF
+          file: release/bustools_linux-${{ github.ref }}.tar.gz
+          asset_name: bustools_linux-${{ github.ref }}.tar.gz
+          tag: ${{ github.ref }}
 
 
   # build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,38 @@ jobs:
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release/bustools_linux-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
-          asset_name: bustools_linux-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          file: release/bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          asset_name: bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
           tag: ${{ github.ref }}
 
+  build-mac:
+    name: Build mac
+    runs-on: macos-latest
+    env:
+      RELEASE_OS: mac
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@master
+      - name: Setup environment
+        id: setup
+        run: echo ::set-output name=RELEASE_VERSION::${GITHUB_REF##*/}
+      - name: Build
+        run: |
+          docker run --rm -v `pwd`:/io \
+          -e RELEASE_OS=$RELEASE_OS \
+          -e RELEASE_VERSION=$RELEASE_VERSION \
+          -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' \
+          phusion/holy-build-box-64:latest /hbb_exe/activate-exec \
+          bash -x -c "cd io && make build_$RELEASE_OS && make compile_release_$RELEASE_OS"
+        env:
+          RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: release/bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          asset_name: bustools_${{ env.RELEASE_OS }}-${{ steps.setup.outputs.RELEASE_VERSION }}.tar.gz
+          tag: ${{ github.ref }}
 
   # build-windows:
   #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           docker run --rm dockbuild/centos5:latest > ./dockbuild \
           && chmod +x ./dockbuild \
-          && ./dockbuild bash -c "make build && make compile_release_$RELEASE_OS"
+          && ./dockbuild -a "-e RELEASE_OS=$RELEASE_OS -e RELEASE_VERSION=$RELEASE_VERSION" bash -c "make build && make compile_release_$RELEASE_OS"
         env:
           RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
       - name: Upload to release
@@ -69,7 +69,7 @@ jobs:
         run: |
           docker run --rm dockcross/windows-static-x64:20191127-92bdbca > ./dockcross \
           && chmod +x ./dockcross \
-          && ./dockcross bash -c "make build && make compile_release_$RELEASE_OS"
+          && ./dockcross -a "-e RELEASE_OS=$RELEASE_OS -e RELEASE_VERSION=$RELEASE_VERSION" bash -c "make build && make compile_release_$RELEASE_OS"
         env:
           RELEASE_VERSION: ${{ steps.setup.outputs.RELEASE_VERSION }}
       - name: Upload to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@master
       - name: Build
-        run: docker run --rm -v `pwd`:/io -e RELEASE_OS='linux' -e RELEASE_VERSION=$GITHUB_REF -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
+        run: docker run --rm -v `pwd`:/io -e RELEASE_OS='linux' -e RELEASE_VERSION=${GITHUB_REF##*/} -e CC='ccache gcc' -e CXX='ccache g++' -e CCACHE_DIR='/io/cache' phusion/holy-build-box-64:latest bash -c "source /hbb_exe/activate && cd io && make build_linux && make compile_release"
       - name: Upload to release
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: release/bustools_linux-${{ github.ref }}.tar.gz
-          asset_name: bustools_linux-${{ github.ref }}.tar.gz
-          tag: ${{ github.ref }}
+          file: release/bustools_linux-${GITHUB_REF##*/}.tar.gz
+          asset_name: bustools_linux-${GITHUB_REF##*/}.tar.gz
+          tag: ${GITHUB_REF##*/}
 
 
   # build-windows:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 cache
 CMakeFiles
+release
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+cache
+CMakeFiles

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY : build_linux build_macos build_windows
+
+build_linux:
+	mkdir build
+	cd build
+	cmake ..
+	make -j

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 RELEASE_OS ?= local
 RELEASE_VERSION ?= local
 
-.PHONY : build_linux build_mac build_windows compile_release_linux compile_release_mac compile_release_windows clean
+.PHONY : build compile_release_linux compile_release_mac compile_release_windows clean
 
 build:
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -9,25 +9,6 @@ build:
 	&& cmake .. -DLINK=static \
 	&& make -j
 
-build_linux:
-	mkdir -p build
-	cmake -S . -B build -DLINK=static
-	# This will fail.
-	- make -C build -j
-	g++ -std=c++11 -O3 -DNDEBUG -static-libgcc -static-libstdc++ -rdynamic \
-	build/src/CMakeFiles/bustools.dir/bustools_main.cpp.o \
-	-o build/src/bustools build/src/libbustools_core.a -lpthread
-
-build_mac:
-	mkdir -p build
-	cmake -S . -B build -DLINK=static
-	make -C build -j
-
-build_windows:
-	mkdir -p build
-	cmake -S . -B build -DLINK=static
-	make -C build -j
-
 compile_release_linux compile_release_mac:
 	mkdir -p release/bustools
 	cp -rf build/src/bustools release/bustools/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ RELEASE_VERSION ?= local
 
 .PHONY : build_linux build_mac build_windows compile_release_linux compile_release_mac compile_release_windows clean
 
+build:
+	mkdir -p build
+	cd build \
+	&& cmake .. -DLINK=static \
+	&& make -j
+
 build_linux:
 	mkdir -p build
 	cmake -S . -B build -DLINK=static
@@ -15,7 +21,11 @@ build_linux:
 build_mac:
 	mkdir -p build
 	cmake -S . -B build -DLINK=static
-	# This will fail.
+	make -C build -j
+
+build_windows:
+	mkdir -p build
+	cmake -S . -B build -DLINK=static
 	make -C build -j
 
 compile_release_linux compile_release_mac:
@@ -27,6 +37,10 @@ compile_release_linux compile_release_mac:
 
 compile_release_windows:
 	mkdir -p release/bustools
+	cp -rf build/src/bustools.exe release/bustools/
+	cp -rf LICENSE release/bustools/
+	cp -rf README.md release/bustools/
+	zip -r release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.zip release/bustools
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ compile_release_linux compile_release_mac:
 	cp -rf LICENSE release/bustools/
 	cp -rf README.md release/bustools/
 	cd release \
-	&& tar -czvf release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.tar.gz bustools
+	&& tar -czvf bustools_${RELEASE_OS}-${RELEASE_VERSION}.tar.gz bustools
 
 compile_release_windows:
 	mkdir -p release/bustools
@@ -23,7 +23,7 @@ compile_release_windows:
 	cp -rf LICENSE release/bustools/
 	cp -rf README.md release/bustools/
 	cd release \
-	&& zip -r release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.zip bustools
+	&& zip -r bustools_${RELEASE_OS}-${RELEASE_VERSION}.zip bustools
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,16 @@ compile_release_linux compile_release_mac:
 	cp -rf build/src/bustools release/bustools/
 	cp -rf LICENSE release/bustools/
 	cp -rf README.md release/bustools/
-	tar -czvf release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.tar.gz -C release bustools
+	cd release \
+	&& tar -czvf release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.tar.gz bustools
 
 compile_release_windows:
 	mkdir -p release/bustools
 	cp -rf build/src/bustools.exe release/bustools/
 	cp -rf LICENSE release/bustools/
 	cp -rf README.md release/bustools/
-	zip -r release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.zip release/bustools
+	cd release \
+	&& zip -r release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.zip bustools
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,26 @@
-.PHONY : build_linux build_macos build_windows
+RELEASE_OS ?= local
+RELEASE_VERSION ?= local
+
+.PHONY : build_linux build_mac build_windows compile_release clean
 
 build_linux:
+	mkdir -p build
 	cmake -S . -B build
-	make -C build
+	# This will fail.
+	- make -C build -j
+	g++ -std=c++11 -O3 -DNDEBUG -static-libgcc -static-libstdc++ -rdynamic \
+	build/src/CMakeFiles/bustools.dir/bustools_main.cpp.o \
+	-o build/src/bustools build/src/libbustools_core.a -lpthread
+
+compile_release:
+	mkdir -p release/bustools
+	cp -rf build/src/bustools release/bustools/
+	cp -rf LICENSE release/bustools/
+	cp -rf README.md release/bustools/
+	tar -czvf release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.tar.gz -C release bustools
+
+clean:
+	rm -rf build
+	rm -rf cache
+	rm -rf CMakeFiles
+	rm -rf release

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 RELEASE_OS ?= local
 RELEASE_VERSION ?= local
 
-.PHONY : build_linux build_mac build_windows compile_release clean
+.PHONY : build_linux build_mac build_windows compile_release_linux compile_release_mac compile_release_windows clean
 
-build_linux:
+build_linux build_mac:
 	mkdir -p build
 	cmake -S . -B build
 	# This will fail.
@@ -12,10 +12,7 @@ build_linux:
 	build/src/CMakeFiles/bustools.dir/bustools_main.cpp.o \
 	-o build/src/bustools build/src/libbustools_core.a -lpthread
 
-compile_release_linux:
-	make compile_release_unix
-
-compile_release_unix:
+compile_release_linux compile_release_mac:
 	mkdir -p release/bustools
 	cp -rf build/src/bustools release/bustools/
 	cp -rf LICENSE release/bustools/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ RELEASE_VERSION ?= local
 
 .PHONY : build_linux build_mac build_windows compile_release_linux compile_release_mac compile_release_windows clean
 
-build_linux build_mac:
+build_linux:
 	mkdir -p build
 	cmake -S . -B build -DLINK=static
 	# This will fail.
@@ -11,6 +11,12 @@ build_linux build_mac:
 	g++ -std=c++11 -O3 -DNDEBUG -static-libgcc -static-libstdc++ -rdynamic \
 	build/src/CMakeFiles/bustools.dir/bustools_main.cpp.o \
 	-o build/src/bustools build/src/libbustools_core.a -lpthread
+
+build_mac:
+	mkdir -p build
+	cmake -S . -B build -DLINK=static
+	# This will fail.
+	make -C build -j
 
 compile_release_linux compile_release_mac:
 	mkdir -p release/bustools

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RELEASE_VERSION ?= local
 
 build_linux build_mac:
 	mkdir -p build
-	cmake -S . -B build
+	cmake -S . -B build -DLINK=static
 	# This will fail.
 	- make -C build -j
 	g++ -std=c++11 -O3 -DNDEBUG -static-libgcc -static-libstdc++ -rdynamic \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .PHONY : build_linux build_macos build_windows
 
 build_linux:
-	mkdir build
-	cd build
-	cmake ..
-	make -j
+	cmake -S . -B build
+	make -C build

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,18 @@ build_linux:
 	build/src/CMakeFiles/bustools.dir/bustools_main.cpp.o \
 	-o build/src/bustools build/src/libbustools_core.a -lpthread
 
-compile_release:
+compile_release_linux:
+	make compile_release_unix
+
+compile_release_unix:
 	mkdir -p release/bustools
 	cp -rf build/src/bustools release/bustools/
 	cp -rf LICENSE release/bustools/
 	cp -rf README.md release/bustools/
 	tar -czvf release/bustools_${RELEASE_OS}-${RELEASE_VERSION}.tar.gz -C release bustools
+
+compile_release_windows:
+	mkdir -p release/bustools
 
 clean:
 	rm -rf build


### PR DESCRIPTION
Use Github actions to automatically build binaries for Windows, Mac, Linux and attach these to the release (as archives).
- Windows is built on `dockcross/windows-static-x64`
- Mac is built on `Catalina 10.15` (provided by github)
- Linux is built on `dockbuild/centos5`

See https://github.com/Lioscro/bustools/releases/tag/actions_test17 for an example.