### PR TITLE
Fixed issues with sort in Windows

### DIFF
--- a/src/bustools_correct.cpp
+++ b/src/bustools_correct.cpp
@@ -67,7 +67,7 @@ void bustools_split_correct(Bustools_opt &opt)
   size_t stat_corr = 0;
   size_t stat_corr_2 = 0;
   size_t stat_uncorr = 0;
-  uint64_t old_barcode;
+  uint64_t old_barcode = 0;
 
   bool dump_bool = opt.dump_bool;
 
@@ -117,10 +117,10 @@ void bustools_split_correct(Bustools_opt &opt)
   uint64_t mask_12; // = (1ULL << (2 * len_12)) - 1;
   uint64_t mask_34; // = (1ULL << (2 * (len_34))) - 1;
 
-  uint64_t mask_1 = (1ULL << (2 * len_1)) - 1;
-  uint64_t mask_2 = (1ULL << (2 * len_2)) - 1;
-  uint64_t mask_3 = (1ULL << (2 * len_3)) - 1;
-  uint64_t mask_4 = (1ULL << (2 * len_4)) - 1;
+  //uint64_t mask_1 = (1ULL << (2 * len_1)) - 1;
+  //uint64_t mask_2 = (1ULL << (2 * len_2)) - 1;
+  //uint64_t mask_3 = (1ULL << (2 * len_3)) - 1;
+  //uint64_t mask_4 = (1ULL << (2 * len_4)) - 1;
 
   while (std::getline(wf, line))
   {
@@ -155,10 +155,10 @@ void bustools_split_correct(Bustools_opt &opt)
   len_3 = len_34 / 2;     //3, 4,4
   len_4 = len_34 - len_3; //4, 4,4
 
-  mask_1 = (1ULL << (2 * len_1)) - 1;
-  mask_2 = (1ULL << (2 * len_2)) - 1;
-  mask_3 = (1ULL << (2 * len_3)) - 1;
-  mask_4 = (1ULL << (2 * len_4)) - 1;
+  uint64_t mask_1 = (1ULL << (2 * len_1)) - 1;
+  uint64_t mask_2 = (1ULL << (2 * len_2)) - 1;
+  uint64_t mask_3 = (1ULL << (2 * len_3)) - 1;
+  uint64_t mask_4 = (1ULL << (2 * len_4)) - 1;
 
   // std::vector<std::pair<Roaring, Roaring>> correct(1ULL << (2 * bc2)); // 4^(bc/2) possible barcodes
 

--- a/src/bustools_mash.cpp
+++ b/src/bustools_mash.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <algorithm>
 #include <queue>
+#include <vector>
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
@@ -176,7 +177,7 @@ void bustools_mash(const Bustools_opt &opt)
     int32_t nr = 0, nw = 0;
 
     int32_t N = 1024;
-    std::queue<BUSData> queue[nf];
+    std::vector<std::queue<BUSData>> queue(nf);
 
     for (int i = 0; i < nf; i++)
     {

--- a/src/bustools_merge.cpp
+++ b/src/bustools_merge.cpp
@@ -83,7 +83,7 @@ void bustools_merge_different_index(const Bustools_opt &opt)
   // put the ecs into a ecmap inv
   std::unordered_map<std::vector<int32_t>, int32_t, SortedVectorHasher> ecmapinv;
 
-  for (int32_t ec; ec < h.ecs.size(); ec++)
+  for (std::size_t ec = 0; ec < h.ecs.size(); ec++)
   {
     ecmapinv.insert({h.ecs[ec], ec});
   }

--- a/src/bustools_sort.cpp
+++ b/src/bustools_sort.cpp
@@ -343,7 +343,6 @@ void bustools_sort(const Bustools_opt &opt)
   {
 	mem = win_mem_max;
   }
-  std::cerr << "code reached" << std::endl;
 #endif
   BUSHeader h;
   size_t N = mem / sizeof(BUSData);

--- a/src/bustools_whitelist.cpp
+++ b/src/bustools_whitelist.cpp
@@ -35,8 +35,8 @@ void bustools_whitelist(Bustools_opt &opt) {
   int wl_count = 0;
   
   uint32_t bc_r = 0, bc_u = 0;
-  uint64_t curr_umi;
-  uint64_t curr_bc;
+  uint64_t curr_umi = 0;
+  uint64_t curr_bc = 0;
   int bc_count = -1;
 
  /* Determine threshold. */ 


### PR DESCRIPTION
Three things:
* A bunch of small issues such as unitialized variables etc. These gave errors with the MSVC compiler, and I thought it may be good to fix them, they are potentially risky. These changes are not tested, but at least compiles - the most risky is probably in mash.
* Sort: now creates the tmp directory automatically on Windows - this didn't work before and gave no good error message
* Sort: Made a workaround for the problem that sort didn't work on windows (read 0 bus records). This is virtually the same as using -m 100000000
